### PR TITLE
Remove un-needed 'export' statements

### DIFF
--- a/installers/template
+++ b/installers/template
@@ -466,7 +466,7 @@ if confirm "Do you wish to continue?"; then
         if ! [ -d $WORKING_DIR/$localdir ]; then
             newline
             echo "Downloading $productname examples..."
-            export TMPDIR=`mktemp -d /tmp/pimoroni.XXXXXX`
+            TMPDIR=`mktemp -d /tmp/pimoroni.XXXXXX`
             cd $TMPDIR
             git clone --depth=1 https://github.com/pimoroni/$gitreponame
             cd $WORKING_DIR
@@ -479,9 +479,9 @@ if confirm "Do you wish to continue?"; then
             if confirm "Examples already exist, shall I replace them?"; then
                 mv $WORKING_DIR/$localdir $WORKING_DIR/$localdir-backup
                 echo "Updating $productname examples..."
-                export TMPDIR=`mktemp -d /tmp/pimoroni.XXXXXX`
+                TMPDIR=`mktemp -d /tmp/pimoroni.XXXXXX`
                 cd $TMPDIR
-                git clone https://github.com/pimoroni/$gitreponame
+                git clone --depth=1 https://github.com/pimoroni/$gitreponame
                 cd $WORKING_DIR
                 mkdir $localdir
                 cp -R $TMPDIR/$examplesdir/* $WORKING_DIR/$localdir/


### PR DESCRIPTION
...since the directory that $TMPDIR refers to gets deleted just a few lines later anyway!

Also make the update-existing-examples use a shallow clone too.
(perhaps in future the identical code-blocks between `mktemp -d ...` and `rm -rf ...` could be extracted into a single reusable function)