### PR TITLE
reverting to fetching 0.36.7

### DIFF
--- a/installers/propellerhat
+++ b/installers/propellerhat
@@ -771,8 +771,9 @@ if confirm "Do you wish to continue?"; then
         newline
         DEBDIR=`mktemp -d /tmp/pimoroni.XXXXXX`
         cd $DEBDIR
-        wget https://github.com/parallaxinc/PropellerIDE/releases/download/0.36.7/propelleride-0.36.7-armhf.deb &> /dev/null
-        sudo dpkg -i $DEBDIR/propelleride-0.36.7-armhf.deb
+        wget https://github.com/parallaxinc/PropellerIDE/releases/download/0.36.7/propelleride-0.38.5-armhf.deb &> /dev/null
+        sudo dpkg -i $DEBDIR/propelleride-0.38.5-armhf.deb
+        sudo rm /usr/bin/bstc && sudo rm /usr/bin/bstl
         sysclean
         newline
         success "All done!"

--- a/installers/propellerhat
+++ b/installers/propellerhat
@@ -771,9 +771,10 @@ if confirm "Do you wish to continue?"; then
         newline
         DEBDIR=`mktemp -d /tmp/pimoroni.XXXXXX`
         cd $DEBDIR
-        wget https://github.com/parallaxinc/PropellerIDE/releases/download/0.36.7/propelleride-0.38.5-armhf.deb &> /dev/null
-        sudo dpkg -i $DEBDIR/propelleride-0.38.5-armhf.deb
-        sudo rm /usr/bin/bstc && sudo rm /usr/bin/bstl
+        wget https://github.com/parallaxinc/PropellerIDE/releases/download/0.36.7/propelleride-0.36.7-armhf.deb &> /dev/null
+        sudo dpkg -i $DEBDIR/propelleride-0.36.7-armhf.deb
+        sudo rm /usr/bin/bstc &> /dev/null
+        sudo rm /usr/bin/bstl &> /dev/null
         sysclean
         newline
         success "All done!"


### PR DESCRIPTION
reverting to fetching 0.36.7 as 0.38.5 has serious bugs unresolved on the Pi. Kept the removal of the x86 though that shouldn’t be relevant to the OLI.