### PR TITLE
-y flag bypasses check_network

### DIFF
--- a/installers/blinkt
+++ b/installers/blinkt
@@ -40,12 +40,9 @@ armv6="yes" # whether armv6 processors are supported
 armv7="yes" # whether armv7 processors are supported
 armv8="yes" # whether armv8 processors are supported
 raspbianonly="no" # whether the script is allowed to run on other OSes
-osreleases=( "Raspbian" ) # list os-releases supported
-oswarning=( "Debian" "Kali" "Mate" "PiTop" "Ubuntu" ) # list experimental os-releases
+osreleases=( "Raspbian" "Mate" "PiTop" ) # list os-releases supported
+oswarning=( "Debian" "Kali" "Ubuntu" ) # list experimental os-releases
 osdeny=( "Darwin" ) # list os-releases specifically disallowed
-squeezesupport="no" # whether Squeeze is supported
-wheezysupport="yes" # whether Wheezy is supported
-jessiesupport="yes" # whether Jessie is supported
 debpackage="na" # the name of the package in apt repo
 piplibname="blinkt" # the name of the lib in pip repo
 pipoverride="yes" # whether the script should give priority to pip repo
@@ -71,7 +68,7 @@ moreaptdep=( "python-numpy" "python-psutil" "python-requests" "python-tweepy" "p
 pipdeplist=() # list of dependencies to source from pip
 morepipdep=() # list of additional pip dependencies
 
-# template 1609301205
+# template 1610251340
 
 FORCE=$1
 ASK_TO_REBOOT=false
@@ -186,7 +183,7 @@ os_check() {
 
     if [ -f /etc/os-release ]; then
         if cat /etc/os-release | grep "Raspbian" > /dev/null; then
-            IS_RASPBIAN=true && IS_SUPPORTED=true
+            IS_RASPBIAN=true
         fi
         if command -v apt-get > /dev/null; then
             for os in ${osreleases[@]}; do
@@ -206,7 +203,7 @@ os_check() {
             done
         fi
     fi
-    if [ -f ~/.pt-dashboard-config ]; then
+    if [ -f ~/.pt-dashboard-config ] || [ -d ~/.pt-dashboard ]; then
         IS_RASPBIAN=false
         for os in ${oswarning[@]}; do
             if [ $os == "PiTop" ]; then
@@ -237,29 +234,21 @@ os_check() {
 }
 
 raspbian_check() {
-    IS_SQUEEZE=false
-    IS_WHEEZY=false
-    IS_JESSIE=false
+    IS_SUPPORTED=false
+    IS_EXPERIMENTAL=false
 
     if [ -f /etc/os-release ]; then
-        if cat /etc/os-release | grep "jessie" > /dev/null; then
-            IS_JESSIE=true
+        if cat /etc/os-release | grep "/sid" > /dev/null; then
+            IS_SUPPORTED=false && IS_EXPERIMENTAL=true
+        elif cat /etc/os-release | grep "stretch" > /dev/null; then
+            IS_SUPPORTED=false && IS_EXPERIMENTAL=true
+        elif cat /etc/os-release | grep "jessie" > /dev/null; then
+            IS_SUPPORTED=true && IS_EXPERIMENTAL=false
         elif cat /etc/os-release | grep "wheezy" > /dev/null; then
-            IS_WHEEZY=true
-        elif cat /etc/os-release | grep "squeeze" > /dev/null; then
-            IS_SQUEEZE=true
+            IS_SUPPORTED=true && IS_EXPERIMENTAL=false
         else
-            echo "Unsupported distribution"
-            exit 1
+            IS_SUPPORTED=false && IS_EXPERIMENTAL=false
         fi
-    fi
-}
-
-raspbian_old() {
-    if $IS_SQUEEZE || $IS_WHEEZY ;then
-        true
-    else
-        false
     fi
 }
 
@@ -281,40 +270,6 @@ home_dir() {
         else
             USER_HOME=$(dscl . -read /Users/$SUDO_USER NFSHomeDirectory | cut -d: -f2)
         fi
-    fi
-}
-
-servd_trig() {
-    if command -v service > /dev/null; then
-        sudo service $1 $2
-    fi
-}
-
-get_init_sys() {
-    if command -v systemctl > /dev/null && systemctl | grep -q '\-\.mount'; then
-        SYSTEMD=1
-    elif [ -f /etc/init.d/cron ] && [ ! -h /etc/init.d/cron ]; then
-        SYSTEMD=0
-    else
-        echo "Unrecognised init system" && exit 1
-    fi
-}
-
-i2c_vc_dtparam() {
-    if [ -e $CONFIG ] && grep -q "^dtparam=i2c_vc=on$" $CONFIG; then
-        newline && echo "i2c0 bus already active"
-    else
-        newline && echo "Enabling i2c0 bus in $CONFIG"
-        echo "dtparam=i2c_vc=on" | sudo tee -a $CONFIG && newline
-    fi
-}
-
-usb_max_power() {
-    if [ -e $CONFIG ] && grep -q "^max_usb_current=1$" $CONFIG; then
-        newline && echo "Max USB current setting already active"
-    else
-        newline && echo "Adjusting USB current setting in $CONFIG"
-        echo "max_usb_current=1" | sudo tee -a $CONFIG && newline
     fi
 }
 
@@ -400,6 +355,40 @@ pip3_pkg_req() {
     fi
 }
 
+usb_max_power() {
+    if [ -e $CONFIG ] && grep -q "^max_usb_current=1$" $CONFIG; then
+        newline && echo "Max USB current setting already active"
+    else
+        newline && echo "Adjusting USB current setting in $CONFIG"
+        echo "max_usb_current=1" | sudo tee -a $CONFIG && newline
+    fi
+}
+
+servd_trig() {
+    if command -v service > /dev/null; then
+        sudo service $1 $2
+    fi
+}
+
+get_init_sys() {
+    if command -v systemctl > /dev/null && systemctl | grep -q '\-\.mount'; then
+        SYSTEMD=1
+    elif [ -f /etc/init.d/cron ] && [ ! -h /etc/init.d/cron ]; then
+        SYSTEMD=0
+    else
+        echo "Unrecognised init system" && exit 1
+    fi
+}
+
+i2c_vc_dtparam() {
+    if [ -e $CONFIG ] && grep -q "^dtparam=i2c_vc=on$" $CONFIG; then
+        newline && echo "i2c0 bus already active"
+    else
+        newline && echo "Enabling i2c0 bus in $CONFIG"
+        echo "dtparam=i2c_vc=on" | sudo tee -a $CONFIG && newline
+    fi
+}
+
 : <<'MAINSTART'
 
 Perform all variables declarations as well as function definition
@@ -441,8 +430,8 @@ fi
 
 arch_check
 os_check
-home_dir
 space_chk
+home_dir
 
 if [ $debugmode != "no" ]; then
     echo "USER_HOME is $USER_HOME" && newline
@@ -455,6 +444,7 @@ fi
 
 if ! $IS_ARMHF; then
     warning "This hardware is not supported, sorry!"
+    warning "Config files have been left untouched"
     newline && exit 1
 fi
 
@@ -476,7 +466,7 @@ fi
 
 if $IS_RASPBIAN; then
     raspbian_check
-    if [ $wheezysupport == "no" ] && raspbian_old; then
+    if ! $IS_SUPPORTED && ! $IS_EXPERIMENTAL; then
         newline && warning "--- Warning ---" && newline
         echo "The $productname installer"
         echo "does not work on this version of Raspbian."
@@ -524,21 +514,21 @@ if confirm "Do you wish to continue?"; then
 
     newline && echo "Checking environment..."
 
-    if ! check_network; then
-        warning "We can't connect to the Internet, check your network!" && exit 1
-    fi
     if [ "$FORCE" != '-y' ]; then
+        if ! check_network; then
+            warning "We can't connect to the Internet, check your network!" && exit 1
+        fi
         sysupdate
-    fi
-    if ! command -v curl > /dev/null; then
-        apt_pkg_install "curl"
-    fi
-    if ! command -v wget > /dev/null; then
-        apt_pkg_install "wget"
-    fi
-    if ! command -v pip > /dev/null; then
-        apt_pkg_install "python-pip"
-        apt_pkg_install "python3-pip"
+        if ! command -v curl > /dev/null; then
+            apt_pkg_install "curl"
+        fi
+        if ! command -v wget > /dev/null; then
+            apt_pkg_install "wget"
+        fi
+        if ! command -v pip > /dev/null; then
+            apt_pkg_install "python-pip"
+            apt_pkg_install "python3-pip"
+        fi
     fi
     pip2_chk && pip3_chk
 

--- a/installers/envirophat
+++ b/installers/envirophat
@@ -40,12 +40,9 @@ armv6="yes" # whether armv6 processors are supported
 armv7="yes" # whether armv7 processors are supported
 armv8="yes" # whether armv8 processors are supported
 raspbianonly="no" # whether the script is allowed to run on other OSes
-osreleases=( "Raspbian" ) # list os-releases supported
-oswarning=( "Debian" "Mate" "PiTop" "Ubuntu" ) # list experimental os-releases
+osreleases=( "Raspbian" "Mate" "PiTop" ) # list os-releases supported
+oswarning=( "Debian" "Ubuntu" ) # list experimental os-releases
 osdeny=( "Darwin" "Kali" ) # list os-releases specifically disallowed
-squeezesupport="no" # whether Squeeze is supported
-wheezysupport="yes" # whether Wheezy is supported
-jessiesupport="yes" # whether Jessie is supported
 debpackage="na" # the name of the package in apt repo
 piplibname="envirophat" # the name of the lib in pip repo
 pipoverride="yes" # whether the script should give priority to pip repo
@@ -71,7 +68,7 @@ moreaptdep=() # list of additional apt dependencies
 pipdeplist=() # list of dependencies to source from pip
 morepipdep=() # list of additional pip dependencies
 
-# template 1609301205
+# template 1610251340
 
 FORCE=$1
 ASK_TO_REBOOT=false
@@ -186,7 +183,7 @@ os_check() {
 
     if [ -f /etc/os-release ]; then
         if cat /etc/os-release | grep "Raspbian" > /dev/null; then
-            IS_RASPBIAN=true && IS_SUPPORTED=true
+            IS_RASPBIAN=true
         fi
         if command -v apt-get > /dev/null; then
             for os in ${osreleases[@]}; do
@@ -206,7 +203,7 @@ os_check() {
             done
         fi
     fi
-    if [ -f ~/.pt-dashboard-config ]; then
+    if [ -f ~/.pt-dashboard-config ] || [ -d ~/.pt-dashboard ]; then
         IS_RASPBIAN=false
         for os in ${oswarning[@]}; do
             if [ $os == "PiTop" ]; then
@@ -237,29 +234,21 @@ os_check() {
 }
 
 raspbian_check() {
-    IS_SQUEEZE=false
-    IS_WHEEZY=false
-    IS_JESSIE=false
+    IS_SUPPORTED=false
+    IS_EXPERIMENTAL=false
 
     if [ -f /etc/os-release ]; then
-        if cat /etc/os-release | grep "jessie" > /dev/null; then
-            IS_JESSIE=true
+        if cat /etc/os-release | grep "/sid" > /dev/null; then
+            IS_SUPPORTED=false && IS_EXPERIMENTAL=true
+        elif cat /etc/os-release | grep "stretch" > /dev/null; then
+            IS_SUPPORTED=false && IS_EXPERIMENTAL=true
+        elif cat /etc/os-release | grep "jessie" > /dev/null; then
+            IS_SUPPORTED=true && IS_EXPERIMENTAL=false
         elif cat /etc/os-release | grep "wheezy" > /dev/null; then
-            IS_WHEEZY=true
-        elif cat /etc/os-release | grep "squeeze" > /dev/null; then
-            IS_SQUEEZE=true
+            IS_SUPPORTED=true && IS_EXPERIMENTAL=false
         else
-            echo "Unsupported distribution"
-            exit 1
+            IS_SUPPORTED=false && IS_EXPERIMENTAL=false
         fi
-    fi
-}
-
-raspbian_old() {
-    if $IS_SQUEEZE || $IS_WHEEZY ;then
-        true
-    else
-        false
     fi
 }
 
@@ -281,40 +270,6 @@ home_dir() {
         else
             USER_HOME=$(dscl . -read /Users/$SUDO_USER NFSHomeDirectory | cut -d: -f2)
         fi
-    fi
-}
-
-servd_trig() {
-    if command -v service > /dev/null; then
-        sudo service $1 $2
-    fi
-}
-
-get_init_sys() {
-    if command -v systemctl > /dev/null && systemctl | grep -q '\-\.mount'; then
-        SYSTEMD=1
-    elif [ -f /etc/init.d/cron ] && [ ! -h /etc/init.d/cron ]; then
-        SYSTEMD=0
-    else
-        echo "Unrecognised init system" && exit 1
-    fi
-}
-
-i2c_vc_dtparam() {
-    if [ -e $CONFIG ] && grep -q "^dtparam=i2c_vc=on$" $CONFIG; then
-        newline && echo "i2c0 bus already active"
-    else
-        newline && echo "Enabling i2c0 bus in $CONFIG"
-        echo "dtparam=i2c_vc=on" | sudo tee -a $CONFIG && newline
-    fi
-}
-
-usb_max_power() {
-    if [ -e $CONFIG ] && grep -q "^max_usb_current=1$" $CONFIG; then
-        newline && echo "Max USB current setting already active"
-    else
-        newline && echo "Adjusting USB current setting in $CONFIG"
-        echo "max_usb_current=1" | sudo tee -a $CONFIG && newline
     fi
 }
 
@@ -400,6 +355,40 @@ pip3_pkg_req() {
     fi
 }
 
+usb_max_power() {
+    if [ -e $CONFIG ] && grep -q "^max_usb_current=1$" $CONFIG; then
+        newline && echo "Max USB current setting already active"
+    else
+        newline && echo "Adjusting USB current setting in $CONFIG"
+        echo "max_usb_current=1" | sudo tee -a $CONFIG && newline
+    fi
+}
+
+servd_trig() {
+    if command -v service > /dev/null; then
+        sudo service $1 $2
+    fi
+}
+
+get_init_sys() {
+    if command -v systemctl > /dev/null && systemctl | grep -q '\-\.mount'; then
+        SYSTEMD=1
+    elif [ -f /etc/init.d/cron ] && [ ! -h /etc/init.d/cron ]; then
+        SYSTEMD=0
+    else
+        echo "Unrecognised init system" && exit 1
+    fi
+}
+
+i2c_vc_dtparam() {
+    if [ -e $CONFIG ] && grep -q "^dtparam=i2c_vc=on$" $CONFIG; then
+        newline && echo "i2c0 bus already active"
+    else
+        newline && echo "Enabling i2c0 bus in $CONFIG"
+        echo "dtparam=i2c_vc=on" | sudo tee -a $CONFIG && newline
+    fi
+}
+
 : <<'MAINSTART'
 
 Perform all variables declarations as well as function definition
@@ -441,8 +430,8 @@ fi
 
 arch_check
 os_check
-home_dir
 space_chk
+home_dir
 
 if [ $debugmode != "no" ]; then
     echo "USER_HOME is $USER_HOME" && newline
@@ -455,6 +444,7 @@ fi
 
 if ! $IS_ARMHF; then
     warning "This hardware is not supported, sorry!"
+    warning "Config files have been left untouched"
     newline && exit 1
 fi
 
@@ -476,7 +466,7 @@ fi
 
 if $IS_RASPBIAN; then
     raspbian_check
-    if [ $wheezysupport == "no" ] && raspbian_old; then
+    if ! $IS_SUPPORTED && ! $IS_EXPERIMENTAL; then
         newline && warning "--- Warning ---" && newline
         echo "The $productname installer"
         echo "does not work on this version of Raspbian."
@@ -524,21 +514,21 @@ if confirm "Do you wish to continue?"; then
 
     newline && echo "Checking environment..."
 
-    if ! check_network; then
-        warning "We can't connect to the Internet, check your network!" && exit 1
-    fi
     if [ "$FORCE" != '-y' ]; then
+        if ! check_network; then
+            warning "We can't connect to the Internet, check your network!" && exit 1
+        fi
         sysupdate
-    fi
-    if ! command -v curl > /dev/null; then
-        apt_pkg_install "curl"
-    fi
-    if ! command -v wget > /dev/null; then
-        apt_pkg_install "wget"
-    fi
-    if ! command -v pip > /dev/null; then
-        apt_pkg_install "python-pip"
-        apt_pkg_install "python3-pip"
+        if ! command -v curl > /dev/null; then
+            apt_pkg_install "curl"
+        fi
+        if ! command -v wget > /dev/null; then
+            apt_pkg_install "wget"
+        fi
+        if ! command -v pip > /dev/null; then
+            apt_pkg_install "python-pip"
+            apt_pkg_install "python3-pip"
+        fi
     fi
     pip2_chk && pip3_chk
 

--- a/installers/getstarted
+++ b/installers/getstarted
@@ -39,13 +39,10 @@ armhfonly="yes" # whether the script is allowed to run on other arch
 armv6="yes" # whether armv6 processors are supported
 armv7="yes" # whether armv7 processors are supported
 armv8="yes" # whether armv8 processors are supported
-raspbianonly="yes" # whether the script is allowed to run on other OSes
+raspbianonly="no" # whether the script is allowed to run on other OSes
 osreleases=( "Raspbian" ) # list os-releases supported
-oswarning=() # list experimental os-releases
-osdeny=() # list os-releases specifically disallowed
-squeezesupport="no" # whether Squeeze is supported
-wheezysupport="yes" # whether Wheezy is supported
-jessiesupport="yes" # whether Jessie is supported
+oswarning=( "Debian" "Mate" "PiTop" ) # list experimental os-releases
+osdeny=( "Darwin" "Kali" "Ubuntu" ) # list os-releases specifically disallowed
 debpackage="na" # the name of the package in apt repo
 piplibname="na" # the name of the lib in pip repo
 pipoverride="yes" # whether the script should give priority to pip repo
@@ -71,7 +68,7 @@ moreaptdep=() # list of additional apt dependencies
 pipdeplist=() # list of dependencies to source from pip
 morepipdep=() # list of additional pip dependencies
 
-# template 1609301205
+# template 1610191240
 
 FORCE=$1
 ASK_TO_REBOOT=false
@@ -186,7 +183,7 @@ os_check() {
 
     if [ -f /etc/os-release ]; then
         if cat /etc/os-release | grep "Raspbian" > /dev/null; then
-            IS_RASPBIAN=true && IS_SUPPORTED=true
+            IS_RASPBIAN=true
         fi
         if command -v apt-get > /dev/null; then
             for os in ${osreleases[@]}; do
@@ -206,7 +203,7 @@ os_check() {
             done
         fi
     fi
-    if [ -f ~/.pt-dashboard-config ]; then
+    if [ -f ~/.pt-dashboard-config ] || [ -d ~/.pt-dashboard ]; then
         IS_RASPBIAN=false
         for os in ${oswarning[@]}; do
             if [ $os == "PiTop" ]; then
@@ -237,29 +234,21 @@ os_check() {
 }
 
 raspbian_check() {
-    IS_SQUEEZE=false
-    IS_WHEEZY=false
-    IS_JESSIE=false
+    IS_SUPPORTED=false
+    IS_EXPERIMENTAL=false
 
     if [ -f /etc/os-release ]; then
-        if cat /etc/os-release | grep "jessie" > /dev/null; then
-            IS_JESSIE=true
+        if cat /etc/os-release | grep "/sid" > /dev/null; then
+            IS_SUPPORTED=false && IS_EXPERIMENTAL=true
+        elif cat /etc/os-release | grep "stretch" > /dev/null; then
+            IS_SUPPORTED=false && IS_EXPERIMENTAL=true
+        elif cat /etc/os-release | grep "jessie" > /dev/null; then
+            IS_SUPPORTED=true && IS_EXPERIMENTAL=false
         elif cat /etc/os-release | grep "wheezy" > /dev/null; then
-            IS_WHEEZY=true
-        elif cat /etc/os-release | grep "squeeze" > /dev/null; then
-            IS_SQUEEZE=true
+            IS_SUPPORTED=true && IS_EXPERIMENTAL=false
         else
-            echo "Unsupported distribution"
-            exit 1
+            IS_SUPPORTED=false && IS_EXPERIMENTAL=false
         fi
-    fi
-}
-
-raspbian_old() {
-    if $IS_SQUEEZE || $IS_WHEEZY ;then
-        true
-    else
-        false
     fi
 }
 
@@ -281,40 +270,6 @@ home_dir() {
         else
             USER_HOME=$(dscl . -read /Users/$SUDO_USER NFSHomeDirectory | cut -d: -f2)
         fi
-    fi
-}
-
-servd_trig() {
-    if command -v service > /dev/null; then
-        sudo service $1 $2
-    fi
-}
-
-get_init_sys() {
-    if command -v systemctl > /dev/null && systemctl | grep -q '\-\.mount'; then
-        SYSTEMD=1
-    elif [ -f /etc/init.d/cron ] && [ ! -h /etc/init.d/cron ]; then
-        SYSTEMD=0
-    else
-        echo "Unrecognised init system" && exit 1
-    fi
-}
-
-i2c_vc_dtparam() {
-    if [ -e $CONFIG ] && grep -q "^dtparam=i2c_vc=on$" $CONFIG; then
-        newline && echo "i2c0 bus already active"
-    else
-        newline && echo "Enabling i2c0 bus in $CONFIG"
-        echo "dtparam=i2c_vc=on" | sudo tee -a $CONFIG && newline
-    fi
-}
-
-usb_max_power() {
-    if [ -e $CONFIG ] && grep -q "^max_usb_current=1$" $CONFIG; then
-        newline && echo "Max USB current setting already active"
-    else
-        newline && echo "Adjusting USB current setting in $CONFIG"
-        echo "max_usb_current=1" | sudo tee -a $CONFIG && newline
     fi
 }
 
@@ -400,6 +355,40 @@ pip3_pkg_req() {
     fi
 }
 
+usb_max_power() {
+    if [ -e $CONFIG ] && grep -q "^max_usb_current=1$" $CONFIG; then
+        newline && echo "Max USB current setting already active"
+    else
+        newline && echo "Adjusting USB current setting in $CONFIG"
+        echo "max_usb_current=1" | sudo tee -a $CONFIG && newline
+    fi
+}
+
+servd_trig() {
+    if command -v service > /dev/null; then
+        sudo service $1 $2
+    fi
+}
+
+get_init_sys() {
+    if command -v systemctl > /dev/null && systemctl | grep -q '\-\.mount'; then
+        SYSTEMD=1
+    elif [ -f /etc/init.d/cron ] && [ ! -h /etc/init.d/cron ]; then
+        SYSTEMD=0
+    else
+        echo "Unrecognised init system" && exit 1
+    fi
+}
+
+i2c_vc_dtparam() {
+    if [ -e $CONFIG ] && grep -q "^dtparam=i2c_vc=on$" $CONFIG; then
+        newline && echo "i2c0 bus already active"
+    else
+        newline && echo "Enabling i2c0 bus in $CONFIG"
+        echo "dtparam=i2c_vc=on" | sudo tee -a $CONFIG && newline
+    fi
+}
+
 : <<'MAINSTART'
 
 Perform all variables declarations as well as function definition
@@ -441,8 +430,8 @@ fi
 
 arch_check
 os_check
-home_dir
 space_chk
+home_dir
 
 if [ $debugmode != "no" ]; then
     echo "USER_HOME is $USER_HOME" && newline
@@ -455,6 +444,7 @@ fi
 
 if ! $IS_ARMHF; then
     warning "This hardware is not supported, sorry!"
+    warning "Config files have been left untouched"
     newline && exit 1
 fi
 
@@ -476,7 +466,7 @@ fi
 
 if $IS_RASPBIAN; then
     raspbian_check
-    if [ $wheezysupport == "no" ] && raspbian_old; then
+    if ! $IS_SUPPORTED && ! $IS_EXPERIMENTAL; then
         newline && warning "--- Warning ---" && newline
         echo "The $productname installer"
         echo "does not work on this version of Raspbian."
@@ -851,16 +841,13 @@ if confirm "Do you wish to continue?"; then
         usb_max_power
         echo "Finalising Install..."
         newline
-        if raspbian_old; then
-            newline
-            echo "Bringing your system up-to-date..."
-            sysupdgrade
-        else
-            sysclean
-        fi
+        echo "Installing Pimoroni Software Installer..."
+        \curl -sS https://get.pimoroni.com/pimstaller | bash -s - "-y"
         newline
-        echo "Expanding filesystem..."
-        \curl -sS get.pimoroni.com/expandfs | sudo bash
+        echo "Bringing your system up-to-date..."
+        \curl -sS https://get.pimoroni.com/uptodate | bash -s - "-y"
+        newline
+        pimstaller
     fi
 
     if $FAILED_PKG; then

--- a/installers/template
+++ b/installers/template
@@ -68,7 +68,7 @@ moreaptdep=() # list of additional apt dependencies
 pipdeplist=() # list of dependencies to source from pip
 morepipdep=() # list of additional pip dependencies
 
-# template 1610191240
+# template 1610251340
 
 FORCE=$1
 ASK_TO_REBOOT=false
@@ -514,21 +514,21 @@ if confirm "Do you wish to continue?"; then
 
     newline && echo "Checking environment..."
 
-    if ! check_network; then
-        warning "We can't connect to the Internet, check your network!" && exit 1
-    fi
     if [ "$FORCE" != '-y' ]; then
+        if ! check_network; then
+            warning "We can't connect to the Internet, check your network!" && exit 1
+        fi
         sysupdate
-    fi
-    if ! command -v curl > /dev/null; then
-        apt_pkg_install "curl"
-    fi
-    if ! command -v wget > /dev/null; then
-        apt_pkg_install "wget"
-    fi
-    if ! command -v pip > /dev/null; then
-        apt_pkg_install "python-pip"
-        apt_pkg_install "python3-pip"
+        if ! command -v curl > /dev/null; then
+            apt_pkg_install "curl"
+        fi
+        if ! command -v wget > /dev/null; then
+            apt_pkg_install "wget"
+        fi
+        if ! command -v pip > /dev/null; then
+            apt_pkg_install "python-pip"
+            apt_pkg_install "python3-pip"
+        fi
     fi
     pip2_chk && pip3_chk
 

--- a/installers/unicornhat
+++ b/installers/unicornhat
@@ -68,7 +68,7 @@ moreaptdep=( "python-numpy" "python3-numpy" "python-flask" "python3-flask" ) # l
 pipdeplist=() # list of dependencies to source from pip
 morepipdep=() # list of additional pip dependencies
 
-# template 1610112330
+# template 1610251340
 
 FORCE=$1
 ASK_TO_REBOOT=false
@@ -273,40 +273,6 @@ home_dir() {
     fi
 }
 
-servd_trig() {
-    if command -v service > /dev/null; then
-        sudo service $1 $2
-    fi
-}
-
-get_init_sys() {
-    if command -v systemctl > /dev/null && systemctl | grep -q '\-\.mount'; then
-        SYSTEMD=1
-    elif [ -f /etc/init.d/cron ] && [ ! -h /etc/init.d/cron ]; then
-        SYSTEMD=0
-    else
-        echo "Unrecognised init system" && exit 1
-    fi
-}
-
-i2c_vc_dtparam() {
-    if [ -e $CONFIG ] && grep -q "^dtparam=i2c_vc=on$" $CONFIG; then
-        newline && echo "i2c0 bus already active"
-    else
-        newline && echo "Enabling i2c0 bus in $CONFIG"
-        echo "dtparam=i2c_vc=on" | sudo tee -a $CONFIG && newline
-    fi
-}
-
-usb_max_power() {
-    if [ -e $CONFIG ] && grep -q "^max_usb_current=1$" $CONFIG; then
-        newline && echo "Max USB current setting already active"
-    else
-        newline && echo "Adjusting USB current setting in $CONFIG"
-        echo "max_usb_current=1" | sudo tee -a $CONFIG && newline
-    fi
-}
-
 space_chk() {
     if command -v stat > /dev/null && ! $IS_MACOSX; then
         if [ $spacereq -gt $(($(stat -f -c "%a*%S" /)/10**6)) ];then
@@ -389,6 +355,40 @@ pip3_pkg_req() {
     fi
 }
 
+usb_max_power() {
+    if [ -e $CONFIG ] && grep -q "^max_usb_current=1$" $CONFIG; then
+        newline && echo "Max USB current setting already active"
+    else
+        newline && echo "Adjusting USB current setting in $CONFIG"
+        echo "max_usb_current=1" | sudo tee -a $CONFIG && newline
+    fi
+}
+
+servd_trig() {
+    if command -v service > /dev/null; then
+        sudo service $1 $2
+    fi
+}
+
+get_init_sys() {
+    if command -v systemctl > /dev/null && systemctl | grep -q '\-\.mount'; then
+        SYSTEMD=1
+    elif [ -f /etc/init.d/cron ] && [ ! -h /etc/init.d/cron ]; then
+        SYSTEMD=0
+    else
+        echo "Unrecognised init system" && exit 1
+    fi
+}
+
+i2c_vc_dtparam() {
+    if [ -e $CONFIG ] && grep -q "^dtparam=i2c_vc=on$" $CONFIG; then
+        newline && echo "i2c0 bus already active"
+    else
+        newline && echo "Enabling i2c0 bus in $CONFIG"
+        echo "dtparam=i2c_vc=on" | sudo tee -a $CONFIG && newline
+    fi
+}
+
 : <<'MAINSTART'
 
 Perform all variables declarations as well as function definition
@@ -430,8 +430,8 @@ fi
 
 arch_check
 os_check
-home_dir
 space_chk
+home_dir
 
 if [ $debugmode != "no" ]; then
     echo "USER_HOME is $USER_HOME" && newline
@@ -514,21 +514,21 @@ if confirm "Do you wish to continue?"; then
 
     newline && echo "Checking environment..."
 
-    if ! check_network; then
-        warning "We can't connect to the Internet, check your network!" && exit 1
-    fi
     if [ "$FORCE" != '-y' ]; then
+        if ! check_network; then
+            warning "We can't connect to the Internet, check your network!" && exit 1
+        fi
         sysupdate
-    fi
-    if ! command -v curl > /dev/null; then
-        apt_pkg_install "curl"
-    fi
-    if ! command -v wget > /dev/null; then
-        apt_pkg_install "wget"
-    fi
-    if ! command -v pip > /dev/null; then
-        apt_pkg_install "python-pip"
-        apt_pkg_install "python3-pip"
+        if ! command -v curl > /dev/null; then
+            apt_pkg_install "curl"
+        fi
+        if ! command -v wget > /dev/null; then
+            apt_pkg_install "wget"
+        fi
+        if ! command -v pip > /dev/null; then
+            apt_pkg_install "python-pip"
+            apt_pkg_install "python3-pip"
+        fi
     fi
     pip2_chk && pip3_chk
 
@@ -827,48 +827,6 @@ if confirm "Do you wish to continue?"; then
         success "$installdir"
         rm -rf $TMPDIR
     fi
-
-# script custom routines
-
-    if [ $customcmd == "no" ]; then
-        if [ -n "$pkgaptremove" ]; then
-            newline && echo "Finalising Install..." && newline
-            sysclean && newline
-        fi
-        newline && echo "All done!" && newline
-        echo "Enjoy your $productname!" && newline
-    else # custom block starts here
-        newline
-        echo "Finalising Install..."
-        if $IS_RASPBIAN; then
-            warning "We need to reconfigure your audio configuration!"
-            echo "This is a necessary step to ensure $productname works correctly"
-            \curl -sS $GETPOOL/audio | sudo bash -s - "3"
-            ASK_TO_REBOOT=true
-            newline
-        fi
-    fi
-
-    if $FAILED_PKG; then
-        warning "Some packages could not be installed, review the output for details!"
-        newline
-    fi
-    if $IS_EXPERIMENTAL; then
-        warning "Support for your operating system is experimental. Please visit"
-        warning "forums.pimoroni.com if you experience issues with this product."
-        newline
-    fi
-
-    if [ "$FORCE" != '-y' ]; then
-        if [ $promptreboot == "yes" ] || $ASK_TO_REBOOT; then
-            sysreboot && newline
-        fi
-    fi
-else
-    newline && echo "Aborting..." && newline
-fi
-
-exit 0
 
 # script custom routines
 

--- a/installers/uptodate
+++ b/installers/uptodate
@@ -21,24 +21,21 @@ DISCLAIMER
 
 productname="na" # the name of the product to install
 scriptname="uptodate" # the name of this script
-spacereq=1 # minimum size required on root partition in MB
+spacereq=50 # minimum size required on root partition in MB
 debugmode="no" # whether the script should use debug routines
 debuguser="none" # optional test git user to use in debug mode
 debugpoint="none" # optional git repo branch or tag to checkout
 forcesudo="no" # whether the script requires to be ran with root privileges
-promptreboot="yes" # whether the script should always prompt user to reboot
+promptreboot="no" # whether the script should always prompt user to reboot
 customcmd="yes" # whether to execute commands specified before exit
 armhfonly="yes" # whether the script is allowed to run on other arch
 armv6="yes" # whether armv6 processors are supported
 armv7="yes" # whether armv7 processors are supported
 armv8="yes" # whether armv8 processors are supported
 raspbianonly="no" # whether the script is allowed to run on other OSes
-macosxsupport="no" # whether Mac OS X is supported by the script
-osreleases=( "Raspbian" ) # list os-releases supported
-oswarning=( "Debian" "Ubuntu" "Kali" "Mate" ) # list experimental os-releases
-squeezesupport="no" # whether Squeeze is supported
-wheezysupport="yes" # whether Wheezy is supported
-jessiesupport="yes" # whether Jessie is supported
+osreleases=( "Debian" "Kali" "Mate" "PiTop" "Raspbian" "Ubuntu" ) # list os-releases supported
+oswarning=() # list experimental os-releases
+osdeny=( "Darwin" ) # list os-releases specifically disallowed
 
 FORCE=$1
 DEVICE_TREE=true
@@ -52,6 +49,8 @@ INITABCONF=/etc/inittab
 BLACKLIST=/etc/modprobe.d/raspi-blacklist.conf
 LOADMOD=/etc/modules
 
+# function define
+
 confirm() {
     if [ "$FORCE" == '-y' ]; then
         true
@@ -63,6 +62,15 @@ confirm() {
             false
         fi
     fi
+}
+
+prompt() {
+        read -r -p "$1 [y/N] " response < /dev/tty
+        if [[ $response =~ ^(yes|y|Y)$ ]]; then
+            true
+        else
+            false
+        fi
 }
 
 success() {
@@ -90,7 +98,10 @@ sysclean() {
 }
 
 sysupdate() {
-    sudo apt-get update
+    if ! $UPDATE_DB; then
+        sudo apt-get update || { warning "Apt failed to update indexes!" && exit 1; }
+        UPDATE_DB=true
+    fi
 }
 
 sysupgrade() {
@@ -103,17 +114,20 @@ sysreboot() {
     warning "Some changes made to your system require"
     warning "your computer to reboot to take effect."
     newline
-    if confirm "Would you like to reboot now?"; then
-        sync
-        sudo reboot
+    if prompt "Would you like to reboot now?"; then
+        sync && sudo reboot
     fi
 }
 
 arch_check() {
+    IS_ARMHF=false
     IS_ARMv6=false
 
-    if uname -m | grep "armv6l" > /dev/null; then
-        IS_ARMv6=true
+    if uname -m | grep "armv.l" > /dev/null; then
+        IS_ARMHF=true
+        if uname -m | grep "armv6l" > /dev/null; then
+            IS_ARMv6=true
+        fi
     fi
 }
 
@@ -122,76 +136,199 @@ os_check() {
     IS_MACOSX=false
     IS_SUPPORTED=false
     IS_EXPERIMENTAL=false
-    
+
     if [ -f /etc/os-release ]; then
         if cat /etc/os-release | grep "Raspbian" > /dev/null; then
-            IS_RASPBIAN=true && IS_SUPPORTED=true
+            IS_RASPBIAN=true
         fi
         if command -v apt-get > /dev/null; then
             for os in ${osreleases[@]}; do
-                if cat /etc/os-release | grep "$os" > /dev/null; then
-                    IS_SUPPORTED=true
+                if cat /etc/os-release | grep $os > /dev/null; then
+                    IS_SUPPORTED=true && IS_EXPERIMENTAL=false
                 fi
             done
             for os in ${oswarning[@]}; do
-                if cat /etc/os-release | grep "$os" > /dev/null; then
-                    IS_EXPERIMENTAL=true
+                if cat /etc/os-release | grep $os > /dev/null; then
+                    IS_SUPPORTED=false && IS_EXPERIMENTAL=true
+                fi
+            done
+            for os in ${osdeny[@]}; do
+                if cat /etc/os-release | grep $os > /dev/null; then
+                    IS_SUPPORTED=false && IS_EXPERIMENTAL=false
                 fi
             done
         fi
-    elif uname -s | grep "Darwin" > /dev/null; then
+    fi
+    if [ -f ~/.pt-dashboard-config ] || [ -d ~/.pt-dashboard ]; then
+        IS_RASPBIAN=false
+        for os in ${oswarning[@]}; do
+            if [ $os == "PiTop" ]; then
+                IS_SUPPORTED=false && IS_EXPERIMENTAL=true
+            fi
+        done
+        for os in ${osdeny[@]}; do
+            if [ $os == "PiTop" ]; then
+                IS_SUPPORTED=false && IS_EXPERIMENTAL=false
+            fi
+        done
+    fi
+    if [ -d ~/.config/ubuntu-mate ]; then
+        for os in ${osdeny[@]}; do
+            if [ $os == "Mate" ]; then
+                IS_SUPPORTED=false && IS_EXPERIMENTAL=false
+            fi
+        done
+    fi
+    if uname -s | grep "Darwin" > /dev/null; then
         IS_MACOSX=true
-        if [ $macosxsupport == "yes" ]; then
-            IS_SUPPORTED=true
-        fi
+        for os in ${osdeny[@]}; do
+            if [ $os == "Darwin" ]; then
+                IS_SUPPORTED=false && IS_EXPERIMENTAL=false
+            fi
+        done
     fi
 }
 
 raspbian_check() {
-    IS_SQUEEZE=false
-    IS_WHEEZY=false
-    IS_JESSIE=false
+    IS_SUPPORTED=false
+    IS_EXPERIMENTAL=false
 
     if [ -f /etc/os-release ]; then
-        if cat /etc/os-release | grep "jessie" > /dev/null; then
-            IS_JESSIE=true
+        if cat /etc/os-release | grep "/sid" > /dev/null; then
+            IS_SUPPORTED=false && IS_EXPERIMENTAL=true
+        elif cat /etc/os-release | grep "stretch" > /dev/null; then
+            IS_SUPPORTED=false && IS_EXPERIMENTAL=true
+        elif cat /etc/os-release | grep "jessie" > /dev/null; then
+            IS_SUPPORTED=true && IS_EXPERIMENTAL=false
         elif cat /etc/os-release | grep "wheezy" > /dev/null; then
-            IS_WHEEZY=true
-        elif cat /etc/os-release | grep "squeeze" > /dev/null; then
-            IS_SQUEEZE=true
+            IS_SUPPORTED=true && IS_EXPERIMENTAL=false
         else
-            echo "Unsupported distribution"
-            exit 1
+            IS_SUPPORTED=false && IS_EXPERIMENTAL=false
         fi
     fi
 }
 
-raspbian_old() {
-    if $IS_SQUEEZE || $IS_WHEEZY ;then
-        true
+home_dir() {
+    if ! $IS_MACOSX; then
+        if [ $EUID -ne 0 ]; then
+            USER_HOME=$(getent passwd $USER | cut -d: -f6)
+        else
+            if [ $SUDO_USER ]; then
+                USER_HOME=$(getent passwd $SUDO_USER | cut -d: -f6)
+            else
+                warning "Running as root and no other sudo user available"
+                exit 1
+            fi
+        fi
     else
-        false
+        if [ $EUID -ne 0 ]; then
+            USER_HOME=$(dscl . -read /Users/$USER NFSHomeDirectory | cut -d: -f2)
+        else
+            USER_HOME=$(dscl . -read /Users/$SUDO_USER NFSHomeDirectory | cut -d: -f2)
+        fi
     fi
+}
+
+space_chk() {
+    if command -v stat > /dev/null && ! $IS_MACOSX; then
+        if [ $spacereq -gt $(($(stat -f -c "%a*%S" /)/10**6)) ];then
+            newline
+            warning  "There is not enough space left to proceed with  installation"
+            if confirm "Would you like to attempt to expand your filesystem?"; then
+                \curl -sS $GETPOOL/expandfs | sudo bash
+                exit 1
+            else
+                newline && exit 1
+            fi
+        fi
+    fi
+}
+
+timestamp() {
+    date +%Y%m%d-%H%M
+}
+
+check_network() {
+    sudo ping -q -w 1 -c 1 `ip r | grep default | cut -d ' ' -f 3` &> /dev/null && return 0 || return 1
 }
 
 : <<'MAINSTART'
 
-Perform all global variables declarations as well as function definition
+Perform all variables declarations as well as function definition
 above this section for clarity, thanks!
 
 MAINSTART
 
+# intro message
+
+if [ $debugmode != "no" ]; then
+    if [ $debuguser != "none" ]; then
+        gitusername="$debuguser"
+    fi
+    if [ $debugpoint != "none" ]; then
+        gitrepobranch="$debugpoint"
+    fi
+    newline
+    warning "DEBUG MODE ENABLED"
+    echo "git user $gitusername and $gitrepobranch branch/tag will be used"
+    newline
+else
+    newline
+    echo "This script will make sure your Raspberry Pi is up to date"
+    newline
+    warning "--- Warning ---"
+    newline
+    echo "Always be careful when running scripts and commands"
+    echo "copied from the internet. Ensure they are from a"
+    echo "trusted source."
+    newline
+    echo "If you want to see what this script does before"
+    echo "running it, you should run:"
+    echo "\curl -sS $GETPOOL/$scriptname"
+    newline
+fi
+
+# checks and init
+
 arch_check
 os_check
+space_chk
+home_dir
+
+if [ $debugmode != "no" ]; then
+    echo "USER_HOME is $USER_HOME" && newline
+    echo "IS_RASPBIAN is $IS_RASPBIAN"
+    echo "IS_MACOSX is $IS_MACOSX"
+    echo "IS_SUPPORTED is $IS_SUPPORTED"
+    echo "IS_EXPERIMENTAL is $IS_EXPERIMENTAL"
+    newline
+fi
 
 if ! $IS_ARMHF; then
     warning "This hardware is not supported, sorry!"
+    warning "Config files have been left untouched"
     newline && exit 1
+fi
+
+if $IS_ARMv8 && [ $armv8 == "no" ]; then
+    warning "Sorry, your CPU is not supported by this installer"
+    newline && exit 1
+elif $IS_ARMv7 && [ $armv7 == "no" ]; then
+    warning "Sorry, your CPU is not supported by this installer"
+    newline && exit 1
+elif $IS_ARMv6 && [ $armv6 == "no" ]; then
+    warning "Sorry, your CPU is not supported by this installer"
+    newline && exit 1
+fi
+
+if [ $raspbianonly == "yes" ] && ! $IS_RASPBIAN;then
+        warning "This script is intended for Raspbian on a Raspberry Pi!"
+        newline && exit 1
 fi
 
 if $IS_RASPBIAN; then
     raspbian_check
-    if [ $wheezysupport == "no" ] && raspbian_old; then
+    if ! $IS_SUPPORTED && ! $IS_EXPERIMENTAL; then
         newline && warning "--- Warning ---" && newline
         echo "The $productname installer"
         echo "does not work on this version of Raspbian."
@@ -199,37 +336,22 @@ if $IS_RASPBIAN; then
         echo "for additional information and support"
         newline && exit 1
     fi
-elif [ $raspbianonly == "yes" ];then
-        warning "This script is intended for Raspbian on a Raspberry Pi!"
-        newline && exit 1
-else
-    if ! $IS_SUPPORTED && ! $IS_EXPERIMENTAL; then
+fi
+
+if ! $IS_SUPPORTED && ! $IS_EXPERIMENTAL; then
         warning "Your operating system is not supported, sorry!"
         newline && exit 1
-    fi
+fi
+
+if $IS_EXPERIMENTAL; then
+    warning "Support for your operating system is experimental. Please visit"
+    warning "forums.pimoroni.com if you experience issues with this product."
+    newline
 fi
 
 if [ $forcesudo == "yes" ]; then
     sudocheck
 fi
-
-newline
-echo "This script will make sure your Raspberry Pi is up to date"
-newline
-warning "--- Warning ---"
-newline
-echo "This script will update software on your Raspberry Pi"
-echo "which might replace or change something you were previously"
-echo "relying upon. Use with care!"
-newline
-echo "Always be careful when running scripts and commands"
-echo "copied from the internet. Ensure they are from a"
-echo "trusted source."
-newline
-echo "If you want to see what this script does before"
-echo "running it, you should run:"
-echo "    \curl -sS get.pimoroni.com/$scriptname"
-newline
 
 if confirm "Do you wish to continue?"; then
     newline


### PR DESCRIPTION
the check_network method seems to cause problem in a, for the time being, small number of cases. Rather than taking it out altogether I'd like to try to figure out the factor affecting those users.

Still, in the interim (and perhaps it can stay that way permanently) I've allowed the 'y' flag to bypass network check, so there is a workaround available to users running into the issue.