### PR TITLE
blinkt ready for pip to apt switch

### DIFF
--- a/installers/blinkt
+++ b/installers/blinkt
@@ -43,7 +43,7 @@ raspbianonly="no" # whether the script is allowed to run on other OSes
 osreleases=( "Raspbian" "Mate" "PiTop" ) # list os-releases supported
 oswarning=( "Debian" "Kali" "Ubuntu" ) # list experimental os-releases
 osdeny=( "Darwin" ) # list os-releases specifically disallowed
-debpackage="na" # the name of the package in apt repo
+debpackage="blinkt" # the name of the package in apt repo
 piplibname="blinkt" # the name of the lib in pip repo
 pipoverride="yes" # whether the script should give priority to pip repo
 pip2support="yes" # whether python2 is supported
@@ -68,7 +68,7 @@ moreaptdep=( "python-numpy" "python-psutil" "python-requests" "python-tweepy" "p
 pipdeplist=() # list of dependencies to source from pip
 morepipdep=() # list of additional pip dependencies
 
-# template 1610311350
+# template 1610311655
 
 FORCE=$1
 ASK_TO_REBOOT=false
@@ -118,15 +118,15 @@ prompt() {
 }
 
 success() {
-    echo "$(tput setaf 2)$1$(tput sgr0)"
+    echo -e "$(tput setaf 2)$1$(tput sgr0)"
 }
 
 inform() {
-    echo "$(tput setaf 6)$1$(tput sgr0)"
+    echo -e "$(tput setaf 6)$1$(tput sgr0)"
 }
 
 warning() {
-    echo "$(tput setaf 1)$1$(tput sgr0)"
+    echo -e "$(tput setaf 1)$1$(tput sgr0)"
 }
 
 newline() {
@@ -314,7 +314,13 @@ apt_pkg_req() {
 
 apt_pkg_install() {
     echo "Installing $1..."
-    sudo apt-get --yes install "$1" 1> /dev/null || warning "Apt failed to install $1!"
+    sudo apt-get --yes install "$1" 1> /dev/null || warning "Apt failed to install $1!" && FAILED_PKG=true
+    newline
+}
+
+apt_deb_install() {
+    echo "Installing $1..."
+    sudo apt-get --yes install "$1" 1> /dev/null || inform "Apt failed to install $1!\nFalling back on pypi..."
     newline
 }
 
@@ -421,16 +427,16 @@ else
     echo "This script will install everything needed to use"
     echo "the $topdir $productname"
     newline
-    warning "--- Warning ---"
-    newline
-    echo "Always be careful when running scripts and commands"
-    echo "copied from the internet. Ensure they are from a"
-    echo "trusted source."
-    newline
-    echo "If you want to see what this script does before"
-    echo "running it, you should run:"
-    echo "\curl -sS $GETPOOL/$scriptname"
-    newline
+    if [ "$FORCE" != '-y' ]; then
+        inform "Always be careful when running scripts and commands"
+        inform "copied from the internet. Ensure they are from a"
+        inform "trusted source."
+        newline
+        echo "If you want to see what this script does before"
+        echo "running it, you should run:"
+        echo "\curl -sS $GETPOOL/$scriptname"
+        newline
+    fi
 fi
 
 # checks and init
@@ -498,12 +504,6 @@ if [ $forcesudo == "yes" ]; then
     sudocheck
 fi
 
-if [ $pipoverride == "yes" ]; then
-    debpackage="na"
-else
-    piplibname="na"
-fi
-
 if [ $i2creq == "yes" ]; then
     echo "Note: $productname requires I2C communication" && newline
 fi
@@ -557,7 +557,7 @@ if confirm "Do you wish to continue?"; then
     if [ $spireq == "yes" ]; then
         newline
         if ls /dev/spi* &> /dev/null; then
-            success "SPI already enabled"
+            inform "SPI already enabled"
         else
             echo "SPI must be enabled for $productname to work"
             \curl -sS $GETPOOL/spi | sudo bash -s - "-y"
@@ -584,7 +584,7 @@ if confirm "Do you wish to continue?"; then
     if [ $i2creq == "yes" ]; then
         newline
         if ls /dev/i2c* &> /dev/null; then
-            success "I2C already enabled"
+            inform "I2C already enabled"
         else
             echo "I2C must be enabled for $productname to work"
             \curl -sS $GETPOOL/i2c | sudo bash -s - "-y"
@@ -684,8 +684,25 @@ if confirm "Do you wish to continue?"; then
             apt_pkg_install "$pkgdep"
         fi
     done
+
+    if [ $pipoverride == "yes" ]; then
+        debpackage="na"
+    fi
+
     if [ $debpackage != "na" ]; then
-        apt_pkg_install "$debpackage"
+        if [ $pip2support != "yes" ] && [ $pip3support != "yes" ]; then
+            apt_deb_install "$debpackage"
+        fi
+        if [ $pip2support == "yes" ] && [ -n $(which python2) ]; then
+            apt_deb_install "python-$debpackage"
+        fi
+        if [ $pip3support == "yes" ] && [ -n $(which python3) ]; then
+            apt_deb_install "python3-$debpackage"
+        fi
+    fi
+
+    if apt_pkg_req "python-$debpackage" &> /dev/null || apt_pkg_req "python3-$debpackage" &> /dev/null; then
+        debpackage="na"
     fi
 
 # pypi repo install
@@ -862,7 +879,7 @@ if confirm "Do you wish to continue?"; then
         newline
     fi
 
-    FAILED_PKG=false # added to avoid bug currently being looked into
+    FAILED_PKG=false # added temporarily while bug investigated
     if $FAILED_PKG; then
         warning "Some packages could not be installed, review the output for details!" && newline
     fi

--- a/installers/debug
+++ b/installers/debug
@@ -20,28 +20,6 @@ was written for this script.
 DISCLAIMER
 
 # script control variables
-#!/bin/bash
-
-: <<'DISCLAIMER'
-
-THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
-EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES
-OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
-NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT
-HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY,
-WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
-FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
-OTHER DEALINGS IN THE SOFTWARE.
-
-This script is licensed under the terms of the MIT license.
-Unless otherwise noted, code reproduced herein
-was written for this script.
-
-- The Pimoroni Crew -
-
-DISCLAIMER
-
-# script control variables
 
 productname="Blinkt!" # the name of the product to install
 scriptname="blinkt" # the name of this script
@@ -65,7 +43,7 @@ raspbianonly="no" # whether the script is allowed to run on other OSes
 osreleases=( "Raspbian" "Mate" "PiTop" ) # list os-releases supported
 oswarning=( "Debian" "Kali" "Ubuntu" ) # list experimental os-releases
 osdeny=( "Darwin" ) # list os-releases specifically disallowed
-debpackage="na" # the name of the package in apt repo
+debpackage="blinkt" # the name of the package in apt repo
 piplibname="blinkt" # the name of the lib in pip repo
 pipoverride="yes" # whether the script should give priority to pip repo
 pip2support="yes" # whether python2 is supported
@@ -90,7 +68,7 @@ moreaptdep=( "python-numpy" "python-psutil" "python-requests" "python-tweepy" "p
 pipdeplist=() # list of dependencies to source from pip
 morepipdep=() # list of additional pip dependencies
 
-# template 1610311345
+# template 1610311655
 
 FORCE=$1
 ASK_TO_REBOOT=false
@@ -140,15 +118,15 @@ prompt() {
 }
 
 success() {
-    echo "$(tput setaf 2)$1$(tput sgr0)"
+    echo -e "$(tput setaf 2)$1$(tput sgr0)"
 }
 
 inform() {
-    echo "$(tput setaf 6)$1$(tput sgr0)"
+    echo -e "$(tput setaf 6)$1$(tput sgr0)"
 }
 
 warning() {
-    echo "$(tput setaf 1)$1$(tput sgr0)"
+    echo -e "$(tput setaf 1)$1$(tput sgr0)"
 }
 
 newline() {
@@ -336,7 +314,13 @@ apt_pkg_req() {
 
 apt_pkg_install() {
     echo "Installing $1..."
-    sudo apt-get --yes install "$1" 1> /dev/null || warning "Apt failed to install $1!"
+    sudo apt-get --yes install "$1" 1> /dev/null || warning "Apt failed to install $1!" && FAILED_PKG=true
+    newline
+}
+
+apt_deb_install() {
+    echo "Installing $1..."
+    sudo apt-get --yes install "$1" 1> /dev/null || inform "Apt failed to install $1!\nFalling back on pypi..."
     newline
 }
 
@@ -443,16 +427,16 @@ else
     echo "This script will install everything needed to use"
     echo "the $topdir $productname"
     newline
-    warning "--- Warning ---"
-    newline
-    echo "Always be careful when running scripts and commands"
-    echo "copied from the internet. Ensure they are from a"
-    echo "trusted source."
-    newline
-    echo "If you want to see what this script does before"
-    echo "running it, you should run:"
-    echo "\curl -sS $GETPOOL/$scriptname"
-    newline
+    if [ "$FORCE" != '-y' ]; then
+        inform "Always be careful when running scripts and commands"
+        inform "copied from the internet. Ensure they are from a"
+        inform "trusted source."
+        newline
+        echo "If you want to see what this script does before"
+        echo "running it, you should run:"
+        echo "\curl -sS $GETPOOL/$scriptname"
+        newline
+    fi
 fi
 
 # checks and init
@@ -520,12 +504,6 @@ if [ $forcesudo == "yes" ]; then
     sudocheck
 fi
 
-if [ $pipoverride == "yes" ]; then
-    debpackage="na"
-else
-    piplibname="na"
-fi
-
 if [ $i2creq == "yes" ]; then
     echo "Note: $productname requires I2C communication" && newline
 fi
@@ -579,7 +557,7 @@ if confirm "Do you wish to continue?"; then
     if [ $spireq == "yes" ]; then
         newline
         if ls /dev/spi* &> /dev/null; then
-            success "SPI already enabled"
+            inform "SPI already enabled"
         else
             echo "SPI must be enabled for $productname to work"
             \curl -sS $GETPOOL/spi | sudo bash -s - "-y"
@@ -606,7 +584,7 @@ if confirm "Do you wish to continue?"; then
     if [ $i2creq == "yes" ]; then
         newline
         if ls /dev/i2c* &> /dev/null; then
-            success "I2C already enabled"
+            inform "I2C already enabled"
         else
             echo "I2C must be enabled for $productname to work"
             \curl -sS $GETPOOL/i2c | sudo bash -s - "-y"
@@ -706,8 +684,25 @@ if confirm "Do you wish to continue?"; then
             apt_pkg_install "$pkgdep"
         fi
     done
+
+    if [ $pipoverride == "yes" ]; then
+        debpackage="na"
+    fi
+
     if [ $debpackage != "na" ]; then
-        apt_pkg_install "$debpackage"
+        if [ $pip2support != "yes" ] && [ $pip3support != "yes" ]; then
+            apt_deb_install "$debpackage"
+        fi
+        if [ $pip2support == "yes" ] && [ -n $(which python2) ]; then
+            apt_deb_install "python-$debpackage"
+        fi
+        if [ $pip3support == "yes" ] && [ -n $(which python3) ]; then
+            apt_deb_install "python3-$debpackage"
+        fi
+    fi
+
+    if apt_pkg_req "python-$debpackage" &> /dev/null || apt_pkg_req "python3-$debpackage" &> /dev/null; then
+        debpackage="na"
     fi
 
 # pypi repo install
@@ -884,6 +879,7 @@ if confirm "Do you wish to continue?"; then
         newline
     fi
 
+    FAILED_PKG=false # added temporarily while bug investigated
     if $FAILED_PKG; then
         warning "Some packages could not be installed, review the output for details!" && newline
     fi

--- a/installers/template
+++ b/installers/template
@@ -68,7 +68,7 @@ moreaptdep=() # list of additional apt dependencies
 pipdeplist=() # list of dependencies to source from pip
 morepipdep=() # list of additional pip dependencies
 
-# template 1610311350
+# template 1610311655
 
 FORCE=$1
 ASK_TO_REBOOT=false
@@ -118,15 +118,15 @@ prompt() {
 }
 
 success() {
-    echo "$(tput setaf 2)$1$(tput sgr0)"
+    echo -e "$(tput setaf 2)$1$(tput sgr0)"
 }
 
 inform() {
-    echo "$(tput setaf 6)$1$(tput sgr0)"
+    echo -e "$(tput setaf 6)$1$(tput sgr0)"
 }
 
 warning() {
-    echo "$(tput setaf 1)$1$(tput sgr0)"
+    echo -e "$(tput setaf 1)$1$(tput sgr0)"
 }
 
 newline() {
@@ -314,7 +314,13 @@ apt_pkg_req() {
 
 apt_pkg_install() {
     echo "Installing $1..."
-    sudo apt-get --yes install "$1" 1> /dev/null || warning "Apt failed to install $1!"
+    sudo apt-get --yes install "$1" 1> /dev/null || warning "Apt failed to install $1!" && FAILED_PKG=true
+    newline
+}
+
+apt_deb_install() {
+    echo "Installing $1..."
+    sudo apt-get --yes install "$1" 1> /dev/null || inform "Apt failed to install $1!\nFalling back on pypi..."
     newline
 }
 
@@ -421,16 +427,16 @@ else
     echo "This script will install everything needed to use"
     echo "the $topdir $productname"
     newline
-    warning "--- Warning ---"
-    newline
-    echo "Always be careful when running scripts and commands"
-    echo "copied from the internet. Ensure they are from a"
-    echo "trusted source."
-    newline
-    echo "If you want to see what this script does before"
-    echo "running it, you should run:"
-    echo "\curl -sS $GETPOOL/$scriptname"
-    newline
+    if [ "$FORCE" != '-y' ]; then
+        inform "Always be careful when running scripts and commands"
+        inform "copied from the internet. Ensure they are from a"
+        inform "trusted source."
+        newline
+        echo "If you want to see what this script does before"
+        echo "running it, you should run:"
+        echo "\curl -sS $GETPOOL/$scriptname"
+        newline
+    fi
 fi
 
 # checks and init
@@ -498,12 +504,6 @@ if [ $forcesudo == "yes" ]; then
     sudocheck
 fi
 
-if [ $pipoverride == "yes" ]; then
-    debpackage="na"
-else
-    piplibname="na"
-fi
-
 if [ $i2creq == "yes" ]; then
     echo "Note: $productname requires I2C communication" && newline
 fi
@@ -557,7 +557,7 @@ if confirm "Do you wish to continue?"; then
     if [ $spireq == "yes" ]; then
         newline
         if ls /dev/spi* &> /dev/null; then
-            success "SPI already enabled"
+            inform "SPI already enabled"
         else
             echo "SPI must be enabled for $productname to work"
             \curl -sS $GETPOOL/spi | sudo bash -s - "-y"
@@ -584,7 +584,7 @@ if confirm "Do you wish to continue?"; then
     if [ $i2creq == "yes" ]; then
         newline
         if ls /dev/i2c* &> /dev/null; then
-            success "I2C already enabled"
+            inform "I2C already enabled"
         else
             echo "I2C must be enabled for $productname to work"
             \curl -sS $GETPOOL/i2c | sudo bash -s - "-y"
@@ -684,8 +684,25 @@ if confirm "Do you wish to continue?"; then
             apt_pkg_install "$pkgdep"
         fi
     done
+
+    if [ $pipoverride == "yes" ]; then
+        debpackage="na"
+    fi
+
     if [ $debpackage != "na" ]; then
-        apt_pkg_install "$debpackage"
+        if [ $pip2support != "yes" ] && [ $pip3support != "yes" ]; then
+            apt_deb_install "$debpackage"
+        fi
+        if [ $pip2support == "yes" ] && [ -n $(which python2) ]; then
+            apt_deb_install "python-$debpackage"
+        fi
+        if [ $pip3support == "yes" ] && [ -n $(which python3) ]; then
+            apt_deb_install "python3-$debpackage"
+        fi
+    fi
+
+    if apt_pkg_req "python-$debpackage" &> /dev/null || apt_pkg_req "python3-$debpackage" &> /dev/null; then
+        debpackage="na"
     fi
 
 # pypi repo install
@@ -862,7 +879,7 @@ if confirm "Do you wish to continue?"; then
         newline
     fi
 
-    FAILED_PKG=false # added to avoid bug currently being looked into
+    FAILED_PKG=false # added temporarily while bug investigated
     if $FAILED_PKG; then
         warning "Some packages could not be installed, review the output for details!" && newline
     fi


### PR DESCRIPTION
... all that is needed for the switch is pipoverride="no".

technically pipoverride enforces the use of pypi rather than apt repo. This is useful for new libs that are yet to be published in the Raspbian repo.

It can also serve in emergency cases, where a hot fix need to be pushed but apt repo syncing is deemed likely to delay unacceptable the fix being public. It's preferable not to use though, it should be fine to revert to the OS owned version later but it's a scenario best not abused.

Note that the fetching of the libraries from the apt-repo, specifically Raspbian at this stage is implemented so that it falls back onto Pipit if it can't be fulfilled, for whatever reason (dpkg db damaged, or whatever else might cause that to happen).

The above is also the expected mechanism for any OS other than Raspbian - though I'm yet to delve deep into the finer details that may make the experience as good for user as possible (i.e not appear to have failed).