### PR TITLE
Change pip format to columns

### DIFF
--- a/installers/inkyphat
+++ b/installers/inkyphat
@@ -105,7 +105,7 @@ RPIGPIO1="raspi-gpio_0.20170105_armhf.deb"
 RPIGPIO2="python-rpi.gpio_0.6.3~jessie-1_armhf.deb"
 RPIGPIO3="python3-rpi.gpio_0.6.3~jessie-1_armhf.deb"
 
-export PIP_FORMAT=legacy
+export PIP_FORMAT=columns
 
 # function define
 


### PR DESCRIPTION
The legacy format for pip list was deprecated in version 10.0.0b1 (2018-03-31) - https://pip.pypa.io/en/stable/news/#id122 - and removed in version 18.0 (2018-07-22) - https://pip.pypa.io/en/stable/news/#id110.

The install script was setting legacy as the pip list format. This meant when pip list was used in an conditional, for example to check RPi.GPIO had been installed, pip would throw a warning about the deprecated format and not output a list as expected.

The warning thrown is: "An error occurred during configuration: option format: invalid choice: 'legacy' (choose from 'columns', 'freeze', 'json')"

Changed PIP_FORMAT to equal columns, now when checks are made against the pip list the script correctly detects the presence of the installed package.

The columns format appears to have been added in pip version 9.0.0 (2016-11-02) - https://pip.pypa.io/en/stable/news/#id130 -  so this should be a safe change.